### PR TITLE
Do not cross compile for Linux aarch64

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,4 @@
 build_platform:
-  linux_aarch64: linux_64
   linux_ppc64le: linux_64
 conda_build:
   error_overlinking: true


### PR DESCRIPTION
Conda forge now has linux-aarch64 runners, so cross compiling is not needed anymore.